### PR TITLE
docs: fix typo on checks recipies

### DIFF
--- a/apps/documentation/pages/docs/checks/recipes.mdx
+++ b/apps/documentation/pages/docs/checks/recipes.mdx
@@ -29,7 +29,7 @@ const hasCodeowner = defineCheck({
 ```ts filename="commonality.config.ts"
 export default defineConfig({
   checks: {
-    '*': [hasReadme()],
+    '*': [hasCodeowner()],
   },
 });
 ```


### PR DESCRIPTION
In the docs, under checks > recipies, the usage section for the codeowner had the wrong name under the example. This PR addresses it by fixing the name.