### PR TITLE
Update check documentation and always install latest @commonalityco/studio 

### DIFF
--- a/apps/commonality/src/cli/commands/studio.ts
+++ b/apps/commonality/src/cli/commands/studio.ts
@@ -93,7 +93,7 @@ export async function ensurePackageInstalled({
       }
     };
 
-    await installPkg.installPackage(dependency, {
+    await installPkg.installPackage(`${dependency}@latest`, {
       dev: true,
       additionalArgs: getAdditionalArgs(),
     });

--- a/apps/documentation/pages/docs/api/checks.mdx
+++ b/apps/documentation/pages/docs/api/checks.mdx
@@ -265,9 +265,9 @@ If a property is not explicitly passed, the check will be passed a default from 
 | :---------------------- | :---------------------------------------- |
 | `context.tags`          | `[]{:ts}`                                 |
 | `context.codeowners`    | `[]{:ts}`                                 |
-| `context.workspace`     | `{relativePath: './', path: './'}{:ts}`   |
-| `context.rootWorkspace` | `{relativePath: './', path: './'}{:ts}`   |
-| `context.allWorkspaces` | `[{relativePath: './', path: './'}]{:ts}` |
+| `context.package`     | `{relativePath: './', path: './'}{:ts}`   |
+| `context.rootPackage` | `{relativePath: './', path: './'}{:ts}`   |
+| `context.allPackages` | `[{relativePath: './', path: './'}]{:ts}` |
 
 **Returns**
 Returns the original check function, however the `validate`, `fix`, and `message` functions

--- a/apps/documentation/pages/docs/api/checks.mdx
+++ b/apps/documentation/pages/docs/api/checks.mdx
@@ -88,9 +88,7 @@ const ensureTSConfigExtends = defineCheck((base: string) => {
   return {
     // ...
     message: async (ctx) => {
-      const tsConfig = await json(
-        path.join(ctx.package.path, 'tsconfig.json'),
-      ).get();
+      const tsConfig = await json(ctx.package.path, 'tsconfig.json').get();
 
       if (!tsConfig) {
         return {
@@ -166,9 +164,7 @@ const ensureTSConfigExtends = defineCheck((base: string) => {
   return {
     // ...
     fix: async (ctx) => {
-      const tsConfig = await json(
-        path.join(ctx.package.path, 'tsconfig.json'),
-      ).get();
+      const tsConfig = await json(ctx.package.path, 'tsconfig.json').get();
 
       if (!tsConfig) {
         return;
@@ -261,10 +257,10 @@ A valid [check](/api/checks#check-properties) object
 Pass options that will be used as the check's [`CheckContext`](/docs/api/checks#checkcontext).
 If a property is not explicitly passed, the check will be passed a default from the table below.
 
-| Name                    | Default                                   |
-| :---------------------- | :---------------------------------------- |
-| `context.tags`          | `[]{:ts}`                                 |
-| `context.codeowners`    | `[]{:ts}`                                 |
+| Name                  | Default                                   |
+| :-------------------- | :---------------------------------------- |
+| `context.tags`        | `[]{:ts}`                                 |
+| `context.codeowners`  | `[]{:ts}`                                 |
 | `context.package`     | `{relativePath: './', path: './'}{:ts}`   |
 | `context.rootPackage` | `{relativePath: './', path: './'}{:ts}`   |
 | `context.allPackages` | `[{relativePath: './', path: './'}]{:ts}` |

--- a/apps/documentation/pages/docs/checks/creating-checks.mdx
+++ b/apps/documentation/pages/docs/checks/creating-checks.mdx
@@ -61,12 +61,13 @@ export default defineConfig({
       {
         name: 'ensure-readme',
         validate: async (ctx) => {
-          return text(path.join(ctx.package.path, 'README.md')).exists();
+          return text(ctx.package.path, 'README.md').exists();
         },
         fix: async (ctx) => {
           // Get the contents of the package.json file
           const packageJson = await json(
-            path.join(ctx.package.path, 'package.json'),
+            ctx.package.path,
+            'package.json',
           ).get();
 
           if (!packageJson) {
@@ -74,7 +75,7 @@ export default defineConfig({
           }
 
           // Create a README.md with some basic content about the package
-          await text(path.join(ctx.package.path, 'README.md')).set([
+          await text(ctx.package.path, 'README.md').set([
             `# ${packageJson.name}`,
             `> ${packageJson.description}`,
           ]);
@@ -100,7 +101,7 @@ import { defineConfig, defineCheck } from 'commonality';
 const ensureScript = defineCheck((scriptName: string, value: string) => ({
   name: 'ensure-script',
   validate: (ctx) => {
-    const packageJson = json(path.join(ctx.package.path, 'package.json')).get();
+    const packageJson = json(ctx.package.path, 'package.json').get();
 
     if (!packageJson) {
       return false;
@@ -109,7 +110,7 @@ const ensureScript = defineCheck((scriptName: string, value: string) => ({
     return packageJson.scripts && packageJson.scripts[scriptName];
   },
   fix: (ctx) => {
-    return json(path.join(ctx.package.path, 'package.json')).merge({
+    return json(ctx.package.path, 'package.json').merge({
       scripts: {
         [scriptName]: value,
       },

--- a/apps/documentation/pages/docs/checks/creating-checks.mdx
+++ b/apps/documentation/pages/docs/checks/creating-checks.mdx
@@ -16,7 +16,7 @@ All checks have three required properties:
 
 <Callout type="info">
   You can view all available check properties and more examples in our
-  [reference documentation](/docs/api/checks).
+  [reference documentation](/docs/reference/checks).
 </Callout>
 
 Here's an example of a simple check that ensures every package has at least one codeowner.
@@ -29,7 +29,7 @@ export default defineConfig({
     '*': [
       {
         name: 'ensure-codeowner',
-        validate: ({ codeowners }) => codeowners.length > 0,
+        validate: (ctx) => ctx.codeowners.length > 0,
         message: 'Packages must have at least one codeowner',
       },
     ],
@@ -60,13 +60,13 @@ export default defineConfig({
     '*': [
       {
         name: 'ensure-readme',
-        validate: async ({ workspace }) => {
-          return text(path.join(workspace.path, 'README.md')).exists();
+        validate: async (ctx) => {
+          return text(path.join(ctx.package.path, 'README.md')).exists();
         },
-        fix: async ({ workspace }) => {
+        fix: async (ctx) => {
           // Get the contents of the package.json file
           const packageJson = await json(
-            path.join(workspace.path, 'package.json'),
+            path.join(ctx.package.path, 'package.json'),
           ).get();
 
           if (!packageJson) {
@@ -74,7 +74,7 @@ export default defineConfig({
           }
 
           // Create a README.md with some basic content about the package
-          await text(path.join(workspace.path, 'README.md')).set([
+          await text(path.join(ctx.package.path, 'README.md')).set([
             `# ${packageJson.name}`,
             `> ${packageJson.description}`,
           ]);
@@ -95,13 +95,12 @@ Instead of defining checks as an object you can use our `defineCheck` helper to 
 Here's an example of a configuration that ensures that all packages with the tag `buildable` have `build` and `dev` scripts.
 
 ```ts filename="commonality.config.ts"
-import { defineConfig } from 'commonality';
-import { defineCheck } from 'commonality/checks';
+import { defineConfig, defineCheck } from 'commonality';
 
 const ensureScript = defineCheck((scriptName: string, value: string) => ({
   name: 'ensure-script',
-  validate: ({ workspace }) => {
-    const packageJson = json(path.join(workspace.path, 'package.json')).get();
+  validate: (ctx) => {
+    const packageJson = json(path.join(ctx.package.path, 'package.json')).get();
 
     if (!packageJson) {
       return false;
@@ -109,8 +108,8 @@ const ensureScript = defineCheck((scriptName: string, value: string) => ({
 
     return packageJson.scripts && packageJson.scripts[scriptName];
   },
-  fix: ({ workspace }) => {
-    return json(path.join(workspace.path, 'package.json')).merge({
+  fix: (ctx) => {
+    return json(path.join(ctx.package.path, 'package.json')).merge({
       scripts: {
         [scriptName]: value,
       },

--- a/apps/documentation/pages/docs/checks/testing-checks.mdx
+++ b/apps/documentation/pages/docs/checks/testing-checks.mdx
@@ -16,23 +16,23 @@ const ensureLicense = defineCheck((license: string = 'MIT') => {
   return {
     name: 'my-team/ensure-license',
     level: 'error',
-    validate: async ({ workspace }) => {
+    validate: async (ctx) => {
       const packageJson = await json(
-        path.join(workspace.path, 'package.json'),
+        path.join(ctx.package.path, 'package.json'),
       ).get();
 
       // This check will fail if the package's license does not match the one specified
       return packageJson.license === license;
     },
-    fix: async ({ workspace }) => {
+    fix: async (ctx) => {
       // We'll want to test that this file gets updated correctly
-      await json(path.join(workspace.path, 'package.json')).merge({
+      await json(path.join(ctx.package.path, 'package.json')).merge({
         license,
       });
     },
-    message: async ({ workspace }) => {
+    message: async (ctx) => {
       const packageJson = await json(
-        path.join(workspace.path, 'package.json'),
+        path.join(ctx.package.path, 'package.json'),
       ).get();
 
       // Since we return multiple messages we should test for each scenario

--- a/apps/documentation/pages/docs/checks/testing-checks.mdx
+++ b/apps/documentation/pages/docs/checks/testing-checks.mdx
@@ -7,6 +7,7 @@ and fix logic is what you would expect it to be.
 
 We recommend using [`mock-fs`](https://github.com/tschaub/mock-fs) along with our [`createTestCheck`](/docs/api/checks#createtestcheck) utility to mock the file system.
 This combination will test your checks end-to-end to ensure that your checks never create unexpected changes.
+
 ## Example
 
 ```ts filename="packages/checks/ensure-license.ts"
@@ -17,23 +18,19 @@ const ensureLicense = defineCheck((license: string = 'MIT') => {
     name: 'my-team/ensure-license',
     level: 'error',
     validate: async (ctx) => {
-      const packageJson = await json(
-        path.join(ctx.package.path, 'package.json'),
-      ).get();
+      const packageJson = await json(ctx.package.path, 'package.json').get();
 
       // This check will fail if the package's license does not match the one specified
       return packageJson.license === license;
     },
     fix: async (ctx) => {
       // We'll want to test that this file gets updated correctly
-      await json(path.join(ctx.package.path, 'package.json')).merge({
+      await json(ctx.package.path, 'package.json').merge({
         license,
       });
     },
     message: async (ctx) => {
-      const packageJson = await json(
-        path.join(ctx.package.path, 'package.json'),
-      ).get();
+      const packageJson = await json(ctx.package.path, 'package.json').get();
 
       // Since we return multiple messages we should test for each scenario
       if (!packageJson || !packageJson.license) {


### PR DESCRIPTION
- Update documentation to reflect the current naming of `CheckContext`
- Always point to the latest installation of `@commonalityco/studio` when running `commonality studio`