### PR TITLE
Fix Commonality Studio constraints sidebar and navigation links

### DIFF
--- a/.changeset/wicked-spoons-compare.md
+++ b/.changeset/wicked-spoons-compare.md
@@ -1,0 +1,7 @@
+---
+"@commonalityco/utils-constraints": patch
+"@commonalityco/ui-constraints": patch
+"@commonalityco/studio": patch
+---
+
+Fixes initialization issues with Commonality Studio and broken links

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ lib-cov
 .node_repl_history
 .yarn-integrity
 
+
 # Serverless directories
 .serverless/
 
@@ -60,6 +61,7 @@ lib-cov
 
 # Build
 lib
+.nx
 .next
 .turbo
 storybook-static/

--- a/apps/studio/src/app/studio-navigation.tsx
+++ b/apps/studio/src/app/studio-navigation.tsx
@@ -73,7 +73,7 @@ function StudioNavigation({
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Docs
+                Documentation
               </Link>
             </Button>
             <ThemeButton

--- a/apps/studio/src/app/studio-navigation.tsx
+++ b/apps/studio/src/app/studio-navigation.tsx
@@ -60,7 +60,7 @@ function StudioNavigation({
           <div className="flex items-center space-x-2">
             <Button variant="link" asChild>
               <Link
-                href="https://commonality.co/feedback"
+                href="https://github.com/commonalityco/commonality/issues/new?title=Feedback+for+%22Commonality+Studio%22&labels=feedback"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -69,7 +69,7 @@ function StudioNavigation({
             </Button>
             <Button variant="link" asChild>
               <Link
-                href="https://commonality.co/docs"
+                href="https://www.commonality.co/docs/overview"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/apps/studio/src/app/studio-navigation.tsx
+++ b/apps/studio/src/app/studio-navigation.tsx
@@ -69,7 +69,7 @@ function StudioNavigation({
             </Button>
             <Button variant="link" asChild>
               <Link
-                href="https://www.commonality.co/docs/overview"
+                href="https://commonality.co/docs/overview"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/packages/constraints/ui-constraints/src/sidebar.tsx
+++ b/packages/constraints/ui-constraints/src/sidebar.tsx
@@ -576,7 +576,7 @@ export function Sidebar({
             onLayout={onLayout}
           >
             <Panel
-              defaultSize={defaultLayout?.[0] ?? 33}
+              defaultSize={defaultLayout?.[0] ?? 34}
               minSize={5}
               className="grid content-start"
             >

--- a/packages/constraints/utils-constraints/src/bind-render-graph-events.ts
+++ b/packages/constraints/utils-constraints/src/bind-render-graph-events.ts
@@ -70,7 +70,7 @@ export const bindRenderGraphEvents = (arguments_: EventHandlerArguments) => {
   renderGraph.nodes().removeListener('mouseover');
   renderGraph
     .nodes()
-    .on('mouseover, tap', (event) =>
+    .on('mouseover', (event) =>
       handleNodeMouseover({ ...arguments_, target: event.target }),
     );
 


### PR DESCRIPTION
* Fixes the "Feedback" and "Docs" links to point to new website
* Fixes the `defaultSize` props for react-resizeable-panels so that total adds up to `100`.
* Fixes the hover interaction for nodes on the constraint graph