### PR TITLE
Fix conformance results

### DIFF
--- a/.changeset/ninety-frogs-hunt.md
+++ b/.changeset/ninety-frogs-hunt.md
@@ -1,0 +1,5 @@
+---
+"@commonalityco/utils-conformance": patch
+---
+
+Fixes an issue where if there were no tags in the project and checks were configured to be run on all packages, no conformance results would be shown.

--- a/apps/documentation/components/bento-section.tsx
+++ b/apps/documentation/components/bento-section.tsx
@@ -47,10 +47,10 @@ export function BentoSection() {
             Discover <span className="italic">frustration-free</span> monorepos
           </Balancer>
         </h2>
-        <p className="max-w-xl mx-auto text-muted-foreground text-base md:text-lg font-medium">
+        <p className="max-w-3xl mx-auto text-muted-foreground text-base md:text-lg font-medium">
           <Balancer>
-            Automate the workflows and maintenance that comes with growing
-            monorepos and package ecosystems.
+            Automate away the tedious maintenance of growing monorepos and
+            package ecosystems.
           </Balancer>
         </p>
       </div>

--- a/apps/documentation/components/bento-section.tsx
+++ b/apps/documentation/components/bento-section.tsx
@@ -49,8 +49,8 @@ export function BentoSection() {
         </h2>
         <p className="max-w-xl mx-auto text-muted-foreground text-base md:text-lg font-medium">
           <Balancer>
-            Commonality helps you tame the chaos that comes with multi-package
-            workspaces and growing package ecosystems.
+            Automate the workflows and maintenance that comes with growing
+            monorepos and package ecosystems.
           </Balancer>
         </p>
       </div>

--- a/packages/conformance/utils-conformance/src/get-conformance-results.test.ts
+++ b/packages/conformance/utils-conformance/src/get-conformance-results.test.ts
@@ -114,7 +114,7 @@ describe('getConformanceResults', () => {
     expect(results[0].package).toEqual(packages[0]);
   });
 
-  it.skip('should return valid results when checks are valid and there are no tags', async () => {
+  it('should return valid results when checks are valid and there are no tags', async () => {
     const conformersByPattern: ProjectConfig['checks'] = {
       '*': [
         {

--- a/packages/conformance/utils-conformance/src/get-conformance-results.test.ts
+++ b/packages/conformance/utils-conformance/src/get-conformance-results.test.ts
@@ -78,7 +78,7 @@ describe('getConformanceResults', () => {
     expect(results[0].package).toEqual(packages[0]);
   });
 
-  it('should return valid results when tests are valid', async () => {
+  it('should return valid results when checks are valid', async () => {
     const conformersByPattern: ProjectConfig['checks'] = {
       '*': [
         {
@@ -98,6 +98,42 @@ describe('getConformanceResults', () => {
       },
     ];
     const tagsData: TagsData[] = [{ packageName: 'pkg-a', tags: ['*'] }];
+
+    const results = await getConformanceResults({
+      conformersByPattern,
+      rootDirectory,
+      packages,
+      tagsData,
+      codeownersData: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe(Status.Pass);
+    expect(results[0].message.title).toBe('Valid workspace');
+    expect(results[0].filter).toBe('*');
+    expect(results[0].package).toEqual(packages[0]);
+  });
+
+  it.skip('should return valid results when checks are valid and there are no tags', async () => {
+    const conformersByPattern: ProjectConfig['checks'] = {
+      '*': [
+        {
+          name: 'ValidWorkspaceConformer',
+          validate: () => true,
+          message: 'Valid workspace',
+        },
+      ],
+    };
+    const rootDirectory = '';
+    const packages: Package[] = [
+      {
+        path: '/path/to/workspace',
+        name: 'pkg-a',
+        version: '1.0.0',
+        type: PackageType.NODE,
+      },
+    ];
+    const tagsData: TagsData[] = [];
 
     const results = await getConformanceResults({
       conformersByPattern,


### PR DESCRIPTION
* Fixes a bug where if there were no tagged packages within a project, checks run using the `*` filter would never match any packages. 
* Adds test for use case
* Updates bento box copy on landing page