### PR TITLE
chore: Link all changesets for packages with `@commonalityco` scope

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,18 +7,5 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
-  "linked": [
-    [
-      "commonality",
-      "@commonalityco/data-codeowners",
-      "@commonalityco/data-conformance",
-      "@commonalityco/data-constraints",
-      "@commonalityco/data-packages",
-      "@commonalityco/data-project",
-      "@commonalityco/data-tags",
-      "@commonalityco/utils-conformance",
-      "@commonalityco/utils-core",
-      "@commonalityco/types"
-    ]
-  ]
+  "linked": [["commonality", "@commonalityco/*"]]
 }

--- a/.changeset/shy-mails-yell.md
+++ b/.changeset/shy-mails-yell.md
@@ -1,0 +1,5 @@
+---
+"@commonalityco/studio": patch
+---
+
+Link all @commonalityco packages and fix missing checks


### PR DESCRIPTION
* Links all changesets for packages with the prefix `@commonalityco`. Previously, `@commonalityco/studio` was omitted from this list and updates to upstream dependencies were not properly triggering a version bump for consumers. 