### PR TITLE
fix: rendering of check accordion in Commonality Studio

### DIFF
--- a/.changeset/fair-coins-deliver.md
+++ b/.changeset/fair-coins-deliver.md
@@ -1,0 +1,6 @@
+---
+'@commonalityco/ui-conformance': patch
+'@commonalityco/studio': patch
+---
+
+Fixes an issue where checks were incorrectly rendering in Commonality Studio

--- a/packages/conformance/ui-conformance/package.json
+++ b/packages/conformance/ui-conformance/package.json
@@ -30,6 +30,7 @@
     "@commonalityco/utils-core": "workspace:*",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.1",
     "@types/react": "^18.2.22",
     "eslint-config-commonality": "workspace:*",
     "react": "^18.2.0",

--- a/packages/conformance/ui-conformance/src/conformance-onboarding-card.tsx
+++ b/packages/conformance/ui-conformance/src/conformance-onboarding-card.tsx
@@ -1,0 +1,41 @@
+import {
+  Button,
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@commonalityco/ui-design-system';
+import { ExternalLink, PackageCheck } from 'lucide-react';
+
+export function ConformanceOnboardingCard() {
+  return (
+    <Card variant="secondary">
+      <CardHeader>
+        <div className="bg-background mb-3 flex h-10 w-10 items-center justify-center rounded-full border">
+          <div className="bg-secondary rounded-full p-1.5">
+            <PackageCheck className="h-5 w-5" />
+          </div>
+        </div>
+
+        <CardTitle>Codify your best practices</CardTitle>
+        <CardDescription>
+          Scale a consistently amazing developer experience with dynamic
+          conformance checks that are run like tests and shared like lint rules.
+        </CardDescription>
+      </CardHeader>
+      <CardFooter>
+        <Button asChild variant="outline" size="sm">
+          <a
+            href="https://commonality.co/docs/checks"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more
+            <ExternalLink className="ml-1 h-3 w-3 -translate-y-px" />
+          </a>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/packages/conformance/ui-conformance/src/conformance-results-list.test.tsx
+++ b/packages/conformance/ui-conformance/src/conformance-results-list.test.tsx
@@ -1,0 +1,280 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import {
+  ConformanceResults,
+  CheckTitle,
+  CheckContent,
+  StatusCount,
+} from './conformance-results-list';
+import type { ConformanceResult } from '@commonalityco/utils-conformance';
+import { PackageType, Status } from '@commonalityco/utils-core';
+
+describe('CheckTitle', () => {
+  it('should render pass status correctly', async () => {
+    const result = {
+      package: {
+        name: 'test-package',
+        path: '/',
+        type: PackageType.NODE,
+        version: '1.0.0',
+      },
+      name: 'test-name',
+      filter: 'tag-one',
+      status: Status.Pass,
+      message: { title: 'This package is cool' },
+    };
+
+    render(<CheckTitle result={result} />);
+
+    const statusElement = screen.getByText('pass');
+
+    expect(statusElement).toBeInTheDocument();
+  });
+
+  it('should render warn status correctly', async () => {
+    const result = {
+      package: {
+        name: 'test-package',
+        path: '/',
+        type: PackageType.NODE,
+        version: '1.0.0',
+      },
+      name: 'test-name',
+      filter: 'tag-one',
+      status: Status.Warn,
+      message: { title: 'This package is cool' },
+    };
+
+    render(<CheckTitle result={result} />);
+
+    const statusElement = screen.getByText('warn');
+
+    expect(statusElement).toBeInTheDocument();
+  });
+
+  it('should render fail status correctly', async () => {
+    const result = {
+      package: {
+        name: 'test-package',
+        path: '/',
+        type: PackageType.NODE,
+        version: '1.0.0',
+      },
+      name: 'test-name',
+      filter: 'tag-one',
+      status: Status.Fail,
+      message: { title: 'This package is cool' },
+    };
+
+    render(<CheckTitle result={result} />);
+
+    const statusElement = screen.getByText('fail');
+
+    expect(statusElement).toBeInTheDocument();
+  });
+});
+
+describe('CheckContent', () => {
+  it('should render no additional context when no filePath and suggestion', async () => {
+    const result = {
+      package: {
+        name: 'test-package',
+        path: '/',
+        type: PackageType.NODE,
+        version: '1.0.0',
+      },
+      name: 'test-name',
+      filter: 'tag-one',
+      status: Status.Pass,
+      message: { title: 'This package is cool' },
+    };
+
+    render(<CheckContent result={result} />);
+
+    const noContextElement = screen.getByText('No additional context');
+
+    expect(noContextElement).toBeInTheDocument();
+  });
+
+  it('should render filePath and suggestion when provided', async () => {
+    const result = {
+      package: {
+        name: 'test-package',
+        path: '/',
+        type: PackageType.NODE,
+        version: '1.0.0',
+      },
+      name: 'test-name',
+      filter: 'tag-one',
+      status: Status.Pass,
+      message: {
+        title: 'This package is cool',
+        filePath: 'path/to/file',
+        suggestion: 'Try this instead',
+      },
+    };
+
+    render(<CheckContent result={result} />);
+
+    const filePathElement = screen.getByText('path/to/file');
+    const suggestionElement = screen.getByText('Try this instead');
+
+    expect(filePathElement).toBeInTheDocument();
+    expect(suggestionElement).toBeInTheDocument();
+  });
+});
+
+describe('StatusCount', () => {
+  it('should render correct counts when failCount, warnCount, and passCount are provided', async () => {
+    render(<StatusCount failCount={2} warnCount={1} passCount={3} />);
+
+    const failCountContainer = screen.getByLabelText('Fail count');
+    const warnCountContainer = screen.getByLabelText('Warning count');
+    const passCountContainer = screen.getByLabelText('Pass count');
+
+    expect(failCountContainer).toHaveClass('text-destructive');
+    expect(warnCountContainer).toHaveClass('text-warning');
+    expect(passCountContainer).toHaveClass('text-success');
+
+    const failCountElement = within(failCountContainer).getByText('2');
+    const warnCountElement = within(warnCountContainer).getByText('1');
+    const passCountElement = within(passCountContainer).getByText('3');
+
+    expect(failCountElement).toBeInTheDocument();
+    expect(warnCountElement).toBeInTheDocument();
+    expect(passCountElement).toBeInTheDocument();
+  });
+
+  it('should render correct counts when failCount, warnCount, and passCount are zero', async () => {
+    render(<StatusCount failCount={0} warnCount={0} passCount={0} />);
+
+    const failCountContainer = screen.getByLabelText('Fail count');
+    const warnCountContainer = screen.getByLabelText('Warning count');
+    const passCountContainer = screen.getByLabelText('Pass count');
+
+    expect(failCountContainer).toHaveClass('text-muted-foreground');
+    expect(warnCountContainer).toHaveClass('text-muted-foreground');
+    expect(passCountContainer).toHaveClass('text-muted-foreground');
+
+    const failCountElement = within(failCountContainer).getByText('0');
+    const warnCountElement = within(warnCountContainer).getByText('0');
+    const passCountElement = within(passCountContainer).getByText('0');
+
+    expect(failCountElement).toBeInTheDocument();
+    expect(warnCountElement).toBeInTheDocument();
+    expect(passCountElement).toBeInTheDocument();
+  });
+});
+
+describe('ConformanceResults', () => {
+  it('should show onboarding when results array is empty', async () => {
+    render(<ConformanceResults results={[]} />);
+
+    const noResultsElement = screen.getByText('Codify your best practices');
+
+    expect(noResultsElement).toBeInTheDocument();
+  });
+
+  it('should render results when results array is not empty', async () => {
+    const results = [
+      {
+        package: {
+          name: 'test-package',
+          path: '/',
+          type: PackageType.NODE,
+          version: '1.0.0',
+        },
+        name: 'test-name',
+        filter: 'tag-one',
+        status: Status.Pass,
+        message: { title: 'This package is cool' },
+      },
+    ] satisfies ConformanceResult[];
+
+    render(<ConformanceResults results={results} />);
+
+    const packageNameElement = screen.getByText('test-package');
+
+    expect(packageNameElement).toBeInTheDocument();
+  });
+
+  it('should render multiple results for the same tag', async () => {
+    const results = [
+      {
+        package: {
+          name: 'test-package',
+          path: '/',
+          type: PackageType.NODE,
+          version: '1.0.0',
+        },
+        filter: 'tag-one',
+        status: Status.Pass,
+        message: { title: 'This package is cool' },
+        name: 'test-name',
+      },
+      {
+        package: {
+          name: 'test-package',
+          path: '/',
+          type: PackageType.NODE,
+          version: '1.0.0',
+        },
+        filter: 'tag-one',
+        status: Status.Pass,
+        message: { title: 'This package is also cool' },
+        name: 'test-name-2',
+      },
+    ] satisfies ConformanceResult[];
+
+    render(<ConformanceResults results={results} />);
+
+    const packageOneNameElement = screen.getByText('This package is cool');
+    const packageTwoNameElement = screen.getByText('This package is also cool');
+    const filterText = screen.getAllByText('#tag-one');
+    const statusText = screen.getAllByText('pass');
+
+    expect(packageOneNameElement).toBeInTheDocument();
+    expect(packageTwoNameElement).toBeInTheDocument();
+    expect(filterText).toHaveLength(1);
+    expect(statusText).toHaveLength(2);
+  });
+
+  it('should expand only one item when two results have the same name', async () => {
+    const results = [
+      {
+        package: {
+          name: 'test-package',
+          path: '/',
+          type: PackageType.NODE,
+          version: '1.0.0',
+        },
+        filter: 'tag-one',
+        status: Status.Pass,
+        message: { title: 'This package is cool' },
+        name: 'test-name',
+      },
+      {
+        package: {
+          name: 'test-package',
+          path: '/',
+          type: PackageType.NODE,
+          version: '1.0.0',
+        },
+        filter: 'tag-one',
+        status: Status.Pass,
+        message: { title: 'This package is also cool' },
+        name: 'test-name',
+      },
+    ] satisfies ConformanceResult[];
+
+    render(<ConformanceResults results={results} />);
+    const accordionElement = screen.getByText('This package is cool');
+
+    await userEvent.click(accordionElement);
+
+    const expandedElements = screen.getAllByRole('button', { expanded: true });
+
+    expect(expandedElements).toHaveLength(1);
+  });
+});

--- a/packages/conformance/ui-conformance/src/conformance-results-list.test.tsx
+++ b/packages/conformance/ui-conformance/src/conformance-results-list.test.tsx
@@ -269,6 +269,7 @@ describe('ConformanceResults', () => {
     ] satisfies ConformanceResult[];
 
     render(<ConformanceResults results={results} />);
+
     const accordionElement = screen.getByText('This package is cool');
 
     await userEvent.click(accordionElement);

--- a/packages/conformance/ui-conformance/src/conformance-results-list.tsx
+++ b/packages/conformance/ui-conformance/src/conformance-results-list.tsx
@@ -4,27 +4,16 @@ import {
   AccordionItem,
   AccordionTrigger,
   Badge,
-  Button,
-  Card,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
   cn,
 } from '@commonalityco/ui-design-system';
 import { Status, formatTagName } from '@commonalityco/utils-core';
-import {
-  AlertTriangle,
-  Check,
-  ExternalLink,
-  PackageCheck,
-  X,
-} from 'lucide-react';
+import { AlertTriangle, Check, X } from 'lucide-react';
 import { Fragment, useMemo } from 'react';
 import {
   getStatusForResults,
   ConformanceResult,
 } from '@commonalityco/utils-conformance';
+import { ConformanceOnboardingCard } from './conformance-onboarding-card';
 
 export function CheckTitle({ result }: { result: ConformanceResult }) {
   const getStatusText = () => {
@@ -49,7 +38,7 @@ export function CheckTitle({ result }: { result: ConformanceResult }) {
         return (
           <span className="text-destructive font-mono font-medium items-center flex flex-nowrap gap-2">
             <X className="h-4 w-4" />
-            pass
+            fail
           </span>
         );
       }
@@ -57,14 +46,14 @@ export function CheckTitle({ result }: { result: ConformanceResult }) {
   };
 
   return (
-    <AccordionTrigger className="flex items-center overflow-hidden w-full">
+    <div className="flex items-center overflow-hidden w-full">
       <div className="grid gap-4 grid-cols-[minmax(0,max-content)_1fr] text-left items-start">
         <div className="flex gap-1 items-center">{getStatusText()}</div>
         <div className="text-left grow shrink basis-auto min-w-0 max-w-full">
           {result.message.title}
         </div>
       </div>
-    </AccordionTrigger>
+    </div>
   );
 }
 
@@ -110,19 +99,27 @@ export function StatusCount({
     <div className="font-mono flex gap-4 shrink-0">
       <span
         className={cn('shrink-0 flex flex-nowrap items-center gap-1', {
-          'text-desructive': failCount > 0,
+          'text-destructive': failCount > 0,
           'text-muted-foreground': failCount === 0,
         })}
+        aria-labelledby="fail-count"
       >
+        <span id="fail-count" className="sr-only">
+          Fail count
+        </span>
         <X className="h-4 w-4" />
         {failCount}
       </span>
       <span
         className={cn('shrink-0 flex flex-nowrap items-center gap-1', {
-          'text-yellow-500': warnCount > 0,
+          'text-warning': warnCount > 0,
           'text-muted-foreground': warnCount === 0,
         })}
+        aria-labelledby="warn-count"
       >
+        <span id="warn-count" className="sr-only">
+          Warning count
+        </span>
         <AlertTriangle className="h-4 w-4" />
         {warnCount}
       </span>
@@ -131,7 +128,11 @@ export function StatusCount({
           'text-success': passCount > 0,
           'text-muted-foreground': passCount === 0,
         })}
+        aria-labelledby="pass-count"
       >
+        <span id="pass-count" className="sr-only">
+          Pass count
+        </span>
         <Check className="h-4 w-4" />
         {passCount}
       </span>
@@ -158,38 +159,6 @@ export function FilterTitle({
         {formatTagName(filter)}
       </Badge>
     </div>
-  );
-}
-
-export function ConformanceOnboardingCard() {
-  return (
-    <Card variant="secondary">
-      <CardHeader>
-        <div className="bg-background mb-3 flex h-10 w-10 items-center justify-center rounded-full border">
-          <div className="bg-secondary rounded-full p-1.5">
-            <PackageCheck className="h-5 w-5" />
-          </div>
-        </div>
-
-        <CardTitle>Codify your best practices</CardTitle>
-        <CardDescription>
-          Scale a consistently amazing developer experience with dynamic
-          conformance checks that are run like tests and shared like lint rules.
-        </CardDescription>
-      </CardHeader>
-      <CardFooter>
-        <Button asChild variant="outline" size="sm">
-          <a
-            href="https://commonality.co/docs/checks"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Learn more
-            <ExternalLink className="ml-1 h-3 w-3 -translate-y-px" />
-          </a>
-        </Button>
-      </CardFooter>
-    </Card>
   );
 }
 
@@ -222,7 +191,7 @@ export function ConformanceResults({
       {Object.entries(resultsByPackageName).map(
         ([packageName, resultsForPackage]) => {
           if (resultsForPackage.length === 0) {
-            return <p>No results</p>;
+            return <p>No checks for package</p>;
           }
 
           const resultsForPackageByFilter: Record<string, ConformanceResult[]> =
@@ -253,13 +222,15 @@ export function ConformanceResults({
                         className="w-full overflow-hidden"
                       >
                         <FilterTitle filter={filter} status={status} />
-                        {resultsForFilter.map((result) => {
-                          const value = `${result.name}-${result.package.name}`;
+                        {resultsForFilter.map((result, index) => {
+                          const value = `${result.name}-${index}`;
 
                           return (
                             <Fragment key={value}>
                               <AccordionItem value={value}>
-                                <CheckTitle result={result} />
+                                <AccordionTrigger>
+                                  <CheckTitle result={result} />
+                                </AccordionTrigger>
                                 <AccordionContent>
                                   <CheckContent result={result} />
                                 </AccordionContent>

--- a/packages/conformance/ui-conformance/src/packages-table.tsx
+++ b/packages/conformance/ui-conformance/src/packages-table.tsx
@@ -28,6 +28,7 @@ import {
   Accordion,
   AccordionItem,
   AccordionContent,
+  AccordionTrigger,
 } from '@commonalityco/ui-design-system';
 import { useState } from 'react';
 import { Status, formatTagName } from '@commonalityco/utils-core';
@@ -186,7 +187,9 @@ export function ConformanceCell<T extends ColumnData>({
 
                         return (
                           <AccordionItem key={key} value={key}>
-                            <CheckTitle result={result} />
+                            <AccordionTrigger>
+                              <CheckTitle result={result} />
+                            </AccordionTrigger>
                             <AccordionContent>
                               <CheckContent result={result} />
                             </AccordionContent>

--- a/packages/conformance/ui-conformance/test/setup.ts
+++ b/packages/conformance/ui-conformance/test/setup.ts
@@ -1,0 +1,7 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/conformance/ui-conformance/vitest.config.ts
+++ b/packages/conformance/ui-conformance/vitest.config.ts
@@ -1,3 +1,9 @@
 import { defineConfig } from 'vitest/config';
 
-export default defineConfig({ test: { globals: true } });
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./test/setup.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.1.2(react-dom@18.2.0)(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.5.1
+        version: 14.5.1(@testing-library/dom@9.3.3)
       '@types/react':
         specifier: ^18.2.22
         version: 18.2.45


### PR DESCRIPTION
* Fixes an issue where accordion items had the same value and key. This caused a bug where if you has multiple checks with the same name but different arguments, all items would expand when clicked.
* Fixes an issue where the text color was incorrectly rendering for checks with the status `warn` and `fail`
* Adds tests for all of the above