### PR TITLE
feat(commonality): Adds `workspaces` property to project configuration

### DIFF
--- a/.changeset/silver-bees-bake.md
+++ b/.changeset/silver-bees-bake.md
@@ -1,0 +1,7 @@
+---
+"@commonalityco/data-project": patch
+"@commonalityco/utils-core": patch
+"commonality": patch
+---
+
+Adds a `workspaces` property to the project configuration file. This will allow you to override your package manager's workspaces. This will also allow integrated monorepos to filter packages without adding a workspaces property to their package manager.

--- a/apps/commonality/src/define-config.ts
+++ b/apps/commonality/src/define-config.ts
@@ -1,5 +1,5 @@
-import { ProjectConfig } from '@commonalityco/utils-core';
+import { ProjectConfigInput } from '@commonalityco/utils-core';
 
-export function defineConfig(config: ProjectConfig): ProjectConfig {
+export function defineConfig(config: ProjectConfigInput): ProjectConfigInput {
   return config;
 }

--- a/packages/data-constraints/src/get-constraint-results.ts
+++ b/packages/data-constraints/src/get-constraint-results.ts
@@ -1,5 +1,5 @@
 import { Dependency, TagsData, ConstraintResult } from '@commonalityco/types';
-import { ProjectConfig } from '@commonalityco/utils-core';
+import { ProjectConfigOutput } from '@commonalityco/utils-core';
 
 const edgeKey = (dep: Dependency) => `${dep.source}|${dep.target}`;
 
@@ -108,7 +108,7 @@ export async function getConstraintResults({
   dependencies = [],
   tagsData = [],
 }: {
-  constraints?: ProjectConfig['constraints'];
+  constraints?: ProjectConfigOutput['constraints'];
   dependencies: Dependency[];
   tagsData: TagsData[];
 }): Promise<ConstraintResult[]> {

--- a/packages/data-project/package.json
+++ b/packages/data-project/package.json
@@ -33,7 +33,6 @@
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^20.10.0",
     "eslint-config-commonality": "workspace:*",
-    "memfs": "^4.6.0",
     "mock-fs": "^5.2.0",
     "typescript": "^5.2.2"
   },

--- a/packages/data-project/package.json
+++ b/packages/data-project/package.json
@@ -33,6 +33,7 @@
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^20.10.0",
     "eslint-config-commonality": "workspace:*",
+    "memfs": "^4.6.0",
     "mock-fs": "^5.2.0",
     "typescript": "^5.2.2"
   },

--- a/packages/data-project/package.json
+++ b/packages/data-project/package.json
@@ -30,8 +30,10 @@
     "@commonalityco/config-tsconfig": "workspace:*",
     "@commonalityco/types": "workspace:*",
     "@types/fs-extra": "^11.0.2",
+    "@types/mock-fs": "^4.13.4",
     "@types/node": "^20.10.0",
     "eslint-config-commonality": "workspace:*",
+    "mock-fs": "^5.2.0",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/packages/data-project/src/get-project-config.ts
+++ b/packages/data-project/src/get-project-config.ts
@@ -1,7 +1,7 @@
 import jiti from 'jiti';
 import { findUp } from 'find-up';
-import { ProjectConfig, projectConfigSchema } from '@commonalityco/utils-core';
-import { ZodError } from 'zod';
+import { projectConfigSchema } from '@commonalityco/utils-core';
+import z, { ZodError } from 'zod';
 
 const normalizeZodMessage = (error: unknown): string => {
   return (error as ZodError).issues
@@ -20,12 +20,14 @@ const normalizeZodMessage = (error: unknown): string => {
     .join('\n');
 };
 
-export const getValidatedProjectConfig = (config: unknown): ProjectConfig => {
+export const getValidatedProjectConfig = (
+  config: unknown,
+): z.output<typeof projectConfigSchema> => {
   return projectConfigSchema.parse(config);
 };
 
 export interface ProjectConfigData {
-  config: ProjectConfig | Record<string, never>;
+  config: z.output<typeof projectConfigSchema> | Record<string, never>;
   filepath: string;
   isEmpty?: boolean;
 }

--- a/packages/data-project/src/get-project-config.ts
+++ b/packages/data-project/src/get-project-config.ts
@@ -1,6 +1,9 @@
 import jiti from 'jiti';
 import { findUp } from 'find-up';
-import { projectConfigSchema } from '@commonalityco/utils-core';
+import {
+  ProjectConfigOutput,
+  projectConfigSchema,
+} from '@commonalityco/utils-core';
 import z, { ZodError } from 'zod';
 
 const normalizeZodMessage = (error: unknown): string => {
@@ -22,12 +25,12 @@ const normalizeZodMessage = (error: unknown): string => {
 
 export const getValidatedProjectConfig = (
   config: unknown,
-): z.output<typeof projectConfigSchema> => {
+): ProjectConfigOutput => {
   return projectConfigSchema.parse(config);
 };
 
 export interface ProjectConfigData {
-  config: z.output<typeof projectConfigSchema> | Record<string, never>;
+  config: ProjectConfigOutput | Record<string, never>;
   filepath: string;
   isEmpty?: boolean;
 }

--- a/packages/data-project/src/get-workspace-globs.ts
+++ b/packages/data-project/src/get-workspace-globs.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import { PackageJson } from '@commonalityco/types';
 import yaml from 'yaml';
 import { PackageManager } from '@commonalityco/utils-core';
+import { getProjectConfig } from './get-project-config';
 
 const defaultWorkspaceGlobs = ['./**'];
 
@@ -13,6 +14,15 @@ export const getWorkspaceGlobs = async ({
   rootDirectory: string;
   packageManager: PackageManager;
 }): Promise<string[]> => {
+  const projectConfig = await getProjectConfig({ rootDirectory });
+
+  if (
+    projectConfig?.config.workspaces &&
+    projectConfig.config.workspaces.length > 0
+  ) {
+    return projectConfig.config.workspaces;
+  }
+
   if (
     packageManager === PackageManager.NPM ||
     packageManager === PackageManager.BUN ||

--- a/packages/data-project/test/fixtures/empty-configuration/commonality.config.ts
+++ b/packages/data-project/test/fixtures/empty-configuration/commonality.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'commonality';
+
+export default defineConfig({});

--- a/packages/data-project/test/fixtures/empty-workspaces/commonality.config.ts
+++ b/packages/data-project/test/fixtures/empty-workspaces/commonality.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'commonality';
+
+export default defineConfig({
+  workspaces: [],
+});

--- a/packages/data-project/test/fixtures/explicit-workspaces/commonality.config.ts
+++ b/packages/data-project/test/fixtures/explicit-workspaces/commonality.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'commonality';
+
+export default defineConfig({
+  workspaces: ['apps/**', 'packages/**'],
+});

--- a/packages/data-project/test/fixtures/npm-workspace/package.json
+++ b/packages/data-project/test/fixtures/npm-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "workspaces": [
-    "./packages/**",
-    "./apps/**"
+    "apps/**",
+    "packages/**"
   ]
 }

--- a/packages/data-project/test/fixtures/pnpm-workspace/pnpm-workspace.yaml
+++ b/packages/data-project/test/fixtures/pnpm-workspace/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
-  - './packages/**'
-  - './apps/**'
+  - 'apps/**'
+  - 'packages/**'

--- a/packages/data-project/test/fixtures/yarn-workspace/package.json
+++ b/packages/data-project/test/fixtures/yarn-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "workspaces": [
-    "./packages/**",
-    "./apps/**"
+    "apps/**",
+    "packages/**"
   ]
 }

--- a/packages/data-project/test/get-project-config.test.ts
+++ b/packages/data-project/test/get-project-config.test.ts
@@ -7,8 +7,19 @@ import { describe, expect, it, test } from 'vitest';
 import { fileURLToPath } from 'node:url';
 
 describe('getValidatedProjectConfig', () => {
+  test('defaults missing properties', () => {
+    const config = getValidatedProjectConfig({});
+
+    expect(config).toEqual({
+      workspaces: [],
+      checks: {},
+      constraints: {},
+    });
+  });
+
   test('strips out invalid properties', () => {
     const config = getValidatedProjectConfig({
+      workspacees: 1,
       checks: {
         '*': [
           {
@@ -41,6 +52,7 @@ describe('getValidatedProjectConfig', () => {
     });
 
     expect(config).toEqual({
+      workspaces: [],
       checks: {
         '*': [
           {
@@ -48,6 +60,7 @@ describe('getValidatedProjectConfig', () => {
             validate: expect.any(Function),
             fix: expect.any(Function),
             message: 'foo',
+            level: 'warning',
           },
         ],
       },
@@ -86,6 +99,8 @@ describe('getProjectConfig', () => {
     });
   });
 
+  it('returns defaults when the configuration file is empty', () => {});
+
   describe('when run in an initialized project', () => {
     it('should return the parsed project config if the file exists and is valid', async () => {
       const rootDirectory = path.join(
@@ -100,6 +115,7 @@ describe('getProjectConfig', () => {
         isEmpty: false,
         filepath: expect.stringContaining('commonality.config.ts'),
         config: {
+          workspaces: [],
           checks: {},
           constraints: {
             '*': {

--- a/packages/data-project/test/get-workspace-globs.test.ts
+++ b/packages/data-project/test/get-workspace-globs.test.ts
@@ -79,7 +79,7 @@ describe('getWorkspaceGlobs', () => {
     });
 
     const workspaceGlobs = await getWorkspaceGlobs({
-      rootDirectory: './',
+      rootDirectory: process.cwd(),
       packageManager: PackageManager.YARN,
     });
 
@@ -97,7 +97,7 @@ describe('getWorkspaceGlobs', () => {
     });
 
     const workspaceGlobs = await getWorkspaceGlobs({
-      rootDirectory: './',
+      rootDirectory: process.cwd(),
       packageManager: PackageManager.PNPM,
     });
 

--- a/packages/data-project/test/get-workspace-globs.test.ts
+++ b/packages/data-project/test/get-workspace-globs.test.ts
@@ -1,7 +1,7 @@
 import { PackageManager } from '@commonalityco/utils-core';
 import path from 'node:path';
 import { getWorkspaceGlobs } from '../src/get-workspace-globs';
-import { afterEach, describe, expect, it, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import mockFs from 'mock-fs';
 
@@ -13,11 +13,12 @@ describe('getWorkspaceGlobs', () => {
   test('returns default globs when there is no package manager workspaces or explicit workspaces configured', async () => {
     mockFs({
       'package.json': JSON.stringify({}),
+      'package-lock.json': JSON.stringify({}),
     });
 
     const config = await getWorkspaceGlobs({
       rootDirectory: './',
-      packageManager: PackageManager.PNPM,
+      packageManager: PackageManager.NPM,
     });
 
     expect(config).toEqual(['./**']);
@@ -58,6 +59,7 @@ describe('getWorkspaceGlobs', () => {
       'package.json': JSON.stringify({
         workspaces: ['apps/**', 'packages/**'],
       }),
+      'package-lock.json': JSON.stringify({}),
     });
 
     const workspaceGlobs = await getWorkspaceGlobs({
@@ -73,6 +75,7 @@ describe('getWorkspaceGlobs', () => {
       'package.json': JSON.stringify({
         workspaces: ['apps/**', 'packages/**'],
       }),
+      'yarn.lock': '',
     });
 
     const workspaceGlobs = await getWorkspaceGlobs({
@@ -85,6 +88,7 @@ describe('getWorkspaceGlobs', () => {
 
   test('returns the workspaces when set with pnpm', async () => {
     mockFs({
+      'pnpm-lock.yaml': '',
       'pnpm-workspace.yaml': `
         packages:
           - 'apps/**'

--- a/packages/data-project/test/get-workspace-globs.test.ts
+++ b/packages/data-project/test/get-workspace-globs.test.ts
@@ -1,23 +1,19 @@
 import { PackageManager } from '@commonalityco/utils-core';
 import path from 'node:path';
 import { getWorkspaceGlobs } from '../src/get-workspace-globs';
-import { afterEach, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { fileURLToPath } from 'node:url';
-import mockFs from 'mock-fs';
 
 describe('getWorkspaceGlobs', () => {
-  afterEach(() => {
-    mockFs.restore();
-  });
-
   test('returns default globs when there is no package manager workspaces or explicit workspaces configured', async () => {
-    mockFs({
-      'package.json': JSON.stringify({}),
-      'package-lock.json': JSON.stringify({}),
-    });
+    const rootDirectory = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      './fixtures',
+      'uninitialized',
+    );
 
     const config = await getWorkspaceGlobs({
-      rootDirectory: './',
+      rootDirectory,
       packageManager: PackageManager.NPM,
     });
 
@@ -55,15 +51,14 @@ describe('getWorkspaceGlobs', () => {
   });
 
   test('returns the workspaces when set with npm', async () => {
-    mockFs({
-      'package.json': JSON.stringify({
-        workspaces: ['apps/**', 'packages/**'],
-      }),
-      'package-lock.json': JSON.stringify({}),
-    });
+    const rootDirectory = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      './fixtures',
+      'npm-workspace',
+    );
 
     const workspaceGlobs = await getWorkspaceGlobs({
-      rootDirectory: './',
+      rootDirectory,
       packageManager: PackageManager.NPM,
     });
 
@@ -71,15 +66,14 @@ describe('getWorkspaceGlobs', () => {
   });
 
   test('returns the workspaces when set with yarn', async () => {
-    mockFs({
-      'package.json': JSON.stringify({
-        workspaces: ['apps/**', 'packages/**'],
-      }),
-      'yarn.lock': '',
-    });
+    const rootDirectory = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      './fixtures',
+      'yarn-workspace',
+    );
 
     const workspaceGlobs = await getWorkspaceGlobs({
-      rootDirectory: process.cwd(),
+      rootDirectory,
       packageManager: PackageManager.YARN,
     });
 
@@ -87,17 +81,14 @@ describe('getWorkspaceGlobs', () => {
   });
 
   test('returns the workspaces when set with pnpm', async () => {
-    mockFs({
-      'pnpm-lock.yaml': '',
-      'pnpm-workspace.yaml': `
-        packages:
-          - 'apps/**'
-          - 'packages/**'
-      `,
-    });
+    const rootDirectory = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      './fixtures',
+      'pnpm-workspace',
+    );
 
     const workspaceGlobs = await getWorkspaceGlobs({
-      rootDirectory: process.cwd(),
+      rootDirectory,
       packageManager: PackageManager.PNPM,
     });
 

--- a/packages/ui-constraints/src/feature-graph-chart.tsx
+++ b/packages/ui-constraints/src/feature-graph-chart.tsx
@@ -8,12 +8,12 @@ import FeatureGraphToolbar from './feature-graph-toolbar';
 import { cn } from '@commonalityco/ui-design-system/cn';
 import debounce from 'lodash-es/debounce';
 import { getElementDefinitions } from '@commonalityco/ui-graph';
-import { ProjectConfig } from '@commonalityco/utils-core';
+import { ProjectConfigOutput } from '@commonalityco/utils-core';
 
 interface GraphProperties {
   packages: Package[];
   results: ConstraintResult[];
-  constraints: ProjectConfig['constraints'];
+  constraints: ProjectConfigOutput['constraints'];
   dependencies: Dependency[];
   theme?: string;
   onPackageClick: (packageName: string) => void;

--- a/packages/utils-conformance/src/create-test-check.ts
+++ b/packages/utils-conformance/src/create-test-check.ts
@@ -1,6 +1,6 @@
 import { Tag, Codeowner, Workspace } from '@commonalityco/types';
 import stripAnsi from 'strip-ansi';
-import { Message, Check, CheckContext } from '@commonalityco/utils-core';
+import { Message, CheckInput, CheckContext } from '@commonalityco/utils-core';
 
 type Awaitable<T> = T | PromiseLike<T>;
 
@@ -22,7 +22,7 @@ interface TestCheckContext {
   tags?: Tag[];
 }
 
-export function createTestCheck<T extends Check>(
+export function createTestCheck<T extends CheckInput>(
   conformer: T,
   options?: TestCheckContext,
 ): TestConformer<T> {

--- a/packages/utils-conformance/src/define-check.ts
+++ b/packages/utils-conformance/src/define-check.ts
@@ -1,8 +1,10 @@
-import { Check } from '@commonalityco/utils-core';
+import { CheckInput } from '@commonalityco/utils-core';
 
-type CheckCreator<C extends Check, O extends unknown[]> = (...args: O) => C;
+type CheckCreator<C extends CheckInput, O extends unknown[]> = (
+  ...args: O
+) => C;
 
-export function defineCheck<T extends Check, O extends unknown[]>(
+export function defineCheck<T extends CheckInput, O extends unknown[]>(
   checkCreator: CheckCreator<T, O>,
 ): CheckCreator<T, O> {
   return checkCreator;

--- a/packages/utils-conformance/src/get-conformance-results.test.ts
+++ b/packages/utils-conformance/src/get-conformance-results.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { getConformanceResults } from './get-conformance-results';
 import { Package, TagsData } from '@commonalityco/types';
 import { PackageType, Status } from '@commonalityco/utils-core';
-import { ProjectConfig } from '@commonalityco/utils-core';
+import { ProjectConfigOutput } from '@commonalityco/utils-core';
 
 describe('getConformanceResults', () => {
   it('should return errors when workspace is not valid and have a level set to error', async () => {
-    const conformersByPattern: ProjectConfig['checks'] = {
+    const conformersByPattern: ProjectConfigOutput['checks'] = {
       '*': [
         {
           name: 'InvalidWorkspaceConformer',
@@ -43,12 +43,13 @@ describe('getConformanceResults', () => {
   });
 
   it('should return errors when workspace is not valid and do not have a level set', async () => {
-    const conformersByPattern: ProjectConfig['checks'] = {
+    const conformersByPattern: ProjectConfigOutput['checks'] = {
       '*': [
         {
           name: 'InvalidWorkspaceConformer',
           validate: () => false,
           message: 'Invalid workspace',
+          level: 'warning',
         },
       ],
     };
@@ -79,12 +80,13 @@ describe('getConformanceResults', () => {
   });
 
   it('should return valid results when checks are valid', async () => {
-    const conformersByPattern: ProjectConfig['checks'] = {
+    const conformersByPattern: ProjectConfigOutput['checks'] = {
       '*': [
         {
           name: 'ValidWorkspaceConformer',
           validate: () => true,
           message: 'Valid workspace',
+          level: 'warning',
         },
       ],
     };
@@ -115,12 +117,13 @@ describe('getConformanceResults', () => {
   });
 
   it('should return valid results when checks are valid and there are no tags', async () => {
-    const conformersByPattern: ProjectConfig['checks'] = {
+    const conformersByPattern: ProjectConfigOutput['checks'] = {
       '*': [
         {
           name: 'ValidWorkspaceConformer',
           validate: () => true,
           message: 'Valid workspace',
+          level: 'warning',
         },
       ],
     };
@@ -151,7 +154,7 @@ describe('getConformanceResults', () => {
   });
 
   it('should handle exceptions during validation', async () => {
-    const conformersByPattern: ProjectConfig['checks'] = {
+    const conformersByPattern: ProjectConfigOutput['checks'] = {
       '*': [
         {
           name: 'ExceptionConformer',
@@ -159,6 +162,7 @@ describe('getConformanceResults', () => {
             throw new Error('Unexpected error');
           },
           message: 'Exception during validation',
+          level: 'warning',
         },
       ],
     };
@@ -188,12 +192,13 @@ describe('getConformanceResults', () => {
   });
 
   it('should handle conformers that target patterns other than *', async () => {
-    const conformersByPattern: ProjectConfig['checks'] = {
+    const conformersByPattern: ProjectConfigOutput['checks'] = {
       tag1: [
         {
           name: 'Tag1Conformer',
           validate: () => true,
           message: 'Valid workspace for tag1',
+          level: 'warning',
         },
       ],
     };
@@ -224,7 +229,7 @@ describe('getConformanceResults', () => {
   });
 
   it('should return correct result when message property is a function', async () => {
-    const conformersByPattern: ProjectConfig['checks'] = {
+    const conformersByPattern: ProjectConfigOutput['checks'] = {
       '*': [
         {
           name: 'MessageFunctionConformer',
@@ -232,6 +237,7 @@ describe('getConformanceResults', () => {
           message: (context) => ({
             title: `Valid package for ${context.package.relativePath}`,
           }),
+          level: 'warning',
         },
       ],
     };

--- a/packages/utils-conformance/src/get-conformance-results.ts
+++ b/packages/utils-conformance/src/get-conformance-results.ts
@@ -1,7 +1,7 @@
 import { TagsData, CodeownersData, Package } from '@commonalityco/types';
 import {
   Status,
-  ProjectConfig,
+  ProjectConfigOutput,
   Check,
   Message,
 } from '@commonalityco/utils-core';
@@ -143,7 +143,7 @@ export const getConformanceResults = async ({
   rootDirectory,
   codeownersData,
 }: {
-  conformersByPattern: ProjectConfig['checks'];
+  conformersByPattern: ProjectConfigOutput['checks'];
   rootDirectory: string;
   packages: Package[];
   tagsData: TagsData[];

--- a/packages/utils-core/src/constants.ts
+++ b/packages/utils-core/src/constants.ts
@@ -101,9 +101,13 @@ const defaultProjectConfigSchema = z.object({
 
 export const projectConfigSchema = defaultProjectConfigSchema;
 
-export type ProjectConfig = z.input<typeof projectConfigSchema>;
+export type ProjectConfigInput = z.input<typeof projectConfigSchema>;
+export type ProjectConfigOutput = z.output<typeof projectConfigSchema>;
 
-export type Check = z.input<typeof checkSchema>;
+export type Check = z.infer<typeof checkSchema>;
+export type CheckInput = z.input<typeof checkSchema>;
+export type CheckOutput = z.output<typeof checkSchema>;
+
 export type CheckContext = z.infer<typeof checkContextSchema>;
 export type Message = z.infer<typeof messageSchema>;
 

--- a/packages/utils-core/src/constants.ts
+++ b/packages/utils-core/src/constants.ts
@@ -84,7 +84,7 @@ const messageSchema = z
 
 const checkSchema = z.object({
   name: z.string(),
-  level: z.union([z.literal('error'), z.literal('warning')]).optional(),
+  level: z.union([z.literal('error'), z.literal('warning')]).default('warning'),
   validate: checkFn,
   fix: checkFn.returns(z.union([z.void(), z.promise(z.void())])).optional(),
   message: z.union([
@@ -93,15 +93,17 @@ const checkSchema = z.object({
   ]),
 });
 
-export const projectConfigSchema = z.object({
-  workspaces: z.array(z.string()),
-  checks: z.record(z.array(checkSchema).default([])).optional().default({}),
-  constraints: z.record(constraintSchema).optional().default({}),
+const defaultProjectConfigSchema = z.object({
+  workspaces: z.array(z.string()).default([]),
+  checks: z.record(z.array(checkSchema).default([])).default({}),
+  constraints: z.record(constraintSchema).default({}),
 });
 
-export type ProjectConfig = z.infer<typeof projectConfigSchema>;
+export const projectConfigSchema = defaultProjectConfigSchema;
 
-export type Check = z.infer<typeof checkSchema>;
+export type ProjectConfig = z.input<typeof projectConfigSchema>;
+
+export type Check = z.input<typeof checkSchema>;
 export type CheckContext = z.infer<typeof checkContextSchema>;
 export type Message = z.infer<typeof messageSchema>;
 

--- a/packages/utils-core/src/constants.ts
+++ b/packages/utils-core/src/constants.ts
@@ -94,6 +94,7 @@ const checkSchema = z.object({
 });
 
 export const projectConfigSchema = z.object({
+  workspaces: z.array(z.string()),
   checks: z.record(z.array(checkSchema).default([])).optional().default({}),
   constraints: z.record(constraintSchema).optional().default({}),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,12 +754,18 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.2
         version: 11.0.4
+      '@types/mock-fs':
+        specifier: ^4.13.4
+        version: 4.13.4
       '@types/node':
         specifier: ^20.10.0
         version: 20.10.6
       eslint-config-commonality:
         specifier: workspace:*
         version: link:../../tooling/config-eslint
+      mock-fs:
+        specifier: ^5.2.0
+        version: 5.2.0
       typescript:
         specifier: ^5.2.2
         version: 5.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,9 +763,6 @@ importers:
       eslint-config-commonality:
         specifier: workspace:*
         version: link:../../tooling/config-eslint
-      memfs:
-        specifier: ^4.6.0
-        version: 4.6.0(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2)
       mock-fs:
         specifier: ^5.2.0
         version: 5.2.0
@@ -10385,10 +10382,6 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  /fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-    dev: true
-
   /fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -11177,11 +11170,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
     dev: false
-
-  /hyperdyperid@1.2.0:
-    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
-    engines: {node: '>=10.18'}
-    dev: true
 
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -12290,22 +12278,6 @@ packages:
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
-  /json-joy@9.9.1(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2):
-    resolution: {integrity: sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==}
-    engines: {node: '>=10.0'}
-    hasBin: true
-    peerDependencies:
-      quill-delta: ^5
-      rxjs: '7'
-      tslib: '2'
-    dependencies:
-      arg: 5.0.2
-      hyperdyperid: 1.2.0
-      quill-delta: 5.1.0
-      rxjs: 7.8.1
-      tslib: 2.6.2
-    dev: true
-
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
@@ -12599,16 +12571,8 @@ packages:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
     dev: true
 
-  /lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
-    dev: true
-
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
-    dev: true
-
-  /lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     dev: true
 
   /lodash.isplainobject@4.0.6:
@@ -12791,20 +12755,6 @@ packages:
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
-    dev: true
-
-  /memfs@4.6.0(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2):
-    resolution: {integrity: sha512-I6mhA1//KEZfKRQT9LujyW6lRbX7RkC24xKododIDO3AGShcaFAMKElv1yFGWX8fD4UaSiwasr3NeQ5TdtHY1A==}
-    engines: {node: '>= 4.0.0'}
-    peerDependencies:
-      tslib: '2'
-    dependencies:
-      json-joy: 9.9.1(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2)
-      thingies: 1.16.0(tslib@2.6.2)
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - quill-delta
-      - rxjs
     dev: true
 
   /memoize-one@6.0.0:
@@ -14134,15 +14084,6 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
     dev: false
-
-  /quill-delta@5.1.0:
-    resolution: {integrity: sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      fast-diff: 1.3.0
-      lodash.clonedeep: 4.5.0
-      lodash.isequal: 4.5.0
-    dev: true
 
   /ramda@0.29.0:
     resolution: {integrity: sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==}
@@ -15748,15 +15689,6 @@ packages:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
     dependencies:
       any-promise: 1.3.0
-    dev: true
-
-  /thingies@1.16.0(tslib@2.6.2):
-    resolution: {integrity: sha512-J23AVs11hSQxuJxvfQyMIaS9z1QpDxOCvMkL3ZxZl8/jmkgmnNGWrlyNxVz6Jbh0U6DuGmHqq6f7zUROfg/ncg==}
-    engines: {node: '>=10.18'}
-    peerDependencies:
-      tslib: ^2
-    dependencies:
-      tslib: 2.6.2
     dev: true
 
   /thread-stream@2.4.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,6 +763,9 @@ importers:
       eslint-config-commonality:
         specifier: workspace:*
         version: link:../../tooling/config-eslint
+      memfs:
+        specifier: ^4.6.0
+        version: 4.6.0(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2)
       mock-fs:
         specifier: ^5.2.0
         version: 5.2.0
@@ -10382,6 +10385,10 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  /fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+    dev: true
+
   /fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -11170,6 +11177,11 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
     dev: false
+
+  /hyperdyperid@1.2.0:
+    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
+    engines: {node: '>=10.18'}
+    dev: true
 
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -12278,6 +12290,22 @@ packages:
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  /json-joy@9.9.1(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2):
+    resolution: {integrity: sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==}
+    engines: {node: '>=10.0'}
+    hasBin: true
+    peerDependencies:
+      quill-delta: ^5
+      rxjs: '7'
+      tslib: '2'
+    dependencies:
+      arg: 5.0.2
+      hyperdyperid: 1.2.0
+      quill-delta: 5.1.0
+      rxjs: 7.8.1
+      tslib: 2.6.2
+    dev: true
+
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
@@ -12571,8 +12599,16 @@ packages:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
     dev: true
 
+  /lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+    dev: true
+
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+    dev: true
+
+  /lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     dev: true
 
   /lodash.isplainobject@4.0.6:
@@ -12755,6 +12791,20 @@ packages:
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /memfs@4.6.0(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2):
+    resolution: {integrity: sha512-I6mhA1//KEZfKRQT9LujyW6lRbX7RkC24xKododIDO3AGShcaFAMKElv1yFGWX8fD4UaSiwasr3NeQ5TdtHY1A==}
+    engines: {node: '>= 4.0.0'}
+    peerDependencies:
+      tslib: '2'
+    dependencies:
+      json-joy: 9.9.1(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2)
+      thingies: 1.16.0(tslib@2.6.2)
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - quill-delta
+      - rxjs
     dev: true
 
   /memoize-one@6.0.0:
@@ -14084,6 +14134,15 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
     dev: false
+
+  /quill-delta@5.1.0:
+    resolution: {integrity: sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      fast-diff: 1.3.0
+      lodash.clonedeep: 4.5.0
+      lodash.isequal: 4.5.0
+    dev: true
 
   /ramda@0.29.0:
     resolution: {integrity: sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==}
@@ -15689,6 +15748,15 @@ packages:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
     dependencies:
       any-promise: 1.3.0
+    dev: true
+
+  /thingies@1.16.0(tslib@2.6.2):
+    resolution: {integrity: sha512-J23AVs11hSQxuJxvfQyMIaS9z1QpDxOCvMkL3ZxZl8/jmkgmnNGWrlyNxVz6Jbh0U6DuGmHqq6f7zUROfg/ncg==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      tslib: ^2
+    dependencies:
+      tslib: 2.6.2
     dev: true
 
   /thread-stream@2.4.1:


### PR DESCRIPTION
Adds a `workspaces` property to the project configuration file. This will allow you to override your package manager's workspaces. This will also allow integrated monorepos to filter packages without adding a workspaces property to their package manager.
