### PR TITLE
fix: allow for yarn berry workspace definition

### DIFF
--- a/.changeset/cold-chairs-pull.md
+++ b/.changeset/cold-chairs-pull.md
@@ -1,0 +1,8 @@
+---
+"@commonalityco/data-project": patch
+"@commonalityco/types": patch
+"@commonalityco/studio": patch
+"commonality": patch
+---
+
+Allow for yarn berry workspaces definition

--- a/apps/studio/src/app/graph/page.tsx
+++ b/apps/studio/src/app/graph/page.tsx
@@ -33,7 +33,6 @@ import { StudioGraphEmpty } from './studio-graph-empty';
 import lazyLoad from 'next/dynamic';
 import { StudioPackageToolbar } from './studio-package-toolbar';
 import { StudioControlBar } from './studio-control-bar';
-import { highlightParser } from './graph-hooks';
 import { DependencyType } from '@commonalityco/utils-core';
 import { parseAsArrayOf, parseAsStringEnum } from 'nuqs';
 

--- a/packages/data-project/src/get-workspace-globs.ts
+++ b/packages/data-project/src/get-workspace-globs.ts
@@ -39,7 +39,15 @@ export const getWorkspaceGlobs = async ({
         return defaultWorkspaceGlobs;
       }
 
-      return rootPackageJson.workspaces;
+      if (Array.isArray(rootPackageJson.workspaces)) {
+        return rootPackageJson.workspaces;
+      }
+
+      if (Array.isArray(rootPackageJson.workspaces?.packages)) {
+        return rootPackageJson.workspaces.packages;
+      }
+
+      return defaultWorkspaceGlobs;
     }
   }
 

--- a/packages/data-project/test/fixtures/yarn-berry-workspace/package.json
+++ b/packages/data-project/test/fixtures/yarn-berry-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "workspaces": {
+    "packages": [
+      "apps/**",
+      "packages/**"
+    ]
+  }
+}

--- a/packages/data-project/test/get-workspace-globs.test.ts
+++ b/packages/data-project/test/get-workspace-globs.test.ts
@@ -80,6 +80,21 @@ describe('getWorkspaceGlobs', () => {
     expect(workspaceGlobs).toEqual(['apps/**', 'packages/**']);
   });
 
+  test('returns the workspaces when set with yarn berry', async () => {
+    const rootDirectory = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      './fixtures',
+      'yarn-berry-workspace',
+    );
+
+    const workspaceGlobs = await getWorkspaceGlobs({
+      rootDirectory,
+      packageManager: PackageManager.YARN,
+    });
+
+    expect(workspaceGlobs).toEqual(['apps/**', 'packages/**']);
+  });
+
   test('returns the workspaces when set with pnpm', async () => {
     const rootDirectory = path.join(
       path.dirname(fileURLToPath(import.meta.url)),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -132,6 +132,6 @@ export type PackageJson = {
   cpu?: Array<string>;
   private?: boolean;
   publishConfig?: Record<string, unknown>;
-  workspaces?: string[];
+  workspaces?: string[] | { packages: string[] };
   [key: string]: unknown;
 };


### PR DESCRIPTION
Previously we would only accept an array of globs as in the `workspaces` property of a package.json. However, yarn berry uses a nested `packages` property to define these globs. This PR enables that property to now correctly be parsed. 
https://yarnpkg.com/features/workspaces